### PR TITLE
use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   },
   "devDependencies": {
     "babel": "^5.8.34"
+  },
+  "dependencies": {
+    "prop-types": "^15.7.2"
   }
 }

--- a/src/autoaction.js
+++ b/src/autoaction.js
@@ -2,9 +2,10 @@
 
 // import storeShape from 'react-redux/lib/utils/storeShape';
 import shallowEqual from 'react-redux/lib/utils/shallowEqual';
-import React, { PropTypes } from 'react';
+import React from 'react';
 import deepEqual from 'deep-equal';
 import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
 
 const BatchActions = {
   isDispatching: false,
@@ -206,7 +207,7 @@ export default function autoaction(autoActions = {}, actionCreators = {}) {
     return class autoaction extends React.Component {
 
       static contextTypes = {
-        store: React.PropTypes.any
+        store: PropTypes.any
       }
 
       constructor(props, context) {


### PR DESCRIPTION
## Description
One of the removed deprecations in React 16 was the ability to import PropTypes from the main React object. Instead, a separate `prop-types` npm package needs to be added as a dependency and imported where needed. This PR makes those changes, allowing for `autoaction` to be used with React 16.